### PR TITLE
Org in path

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -74,8 +74,8 @@ class GitHubFileBrowser extends Widget {
         const resource = parsePath(this._browser.model.path.split(':')[1]);
         url = URLExt.join(url, resource.user);
         if (resource.repository) {
-          const dir = URLExt.join(resource.repository, resource.path);
-          url = URLExt.join(url, resource.repository, 'tree', 'master', dir);
+          url = URLExt.join(url, resource.repository,
+                            'tree', 'master', resource.path);
         }
         window.open(url);
       },


### PR DESCRIPTION
Addresses #17.

Includes the org/user in the path for the GitHub file browser. This makes files on GitHub have unique paths from the perspective of JupyterLab, which is less error prone, and makes restoring upon page refresh work correctly.