### PR TITLE
Fix capitalization of JupyterLab in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jupyterlab GitHub
+# JupyterLab GitHub
 
 A JupyterLab extension for accessing GitHub repositories.
 


### PR DESCRIPTION
I fixed the title but the gitception png should be updated at some point too.