### PR TITLE
Add package metadata for discovery compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [
     "github",
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab extension"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab-github",
   "bugs": {
@@ -54,6 +55,14 @@
     "typescript": "~2.6.2"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "discovery": {
+      "server": {
+        "managers": ["pip"],
+        "base": {
+          "name": "jupyterlab_github"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This adds metadata for compatibility with [jupyterlab-discovery](http://jupyterlab-discovery.readthedocs.io):
 - It adds the "jupyterlab extension" keyword for (reasonably) explicit filtering of extensions.
 - It adds metadata indicating that this package has a recommended server extension called `jupyterlab_github` that is available on pip. See [docs](http://jupyterlab-discovery.readthedocs.io/en/latest/extension-authors.html) for details.