### PR TITLE
Update keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "github",
     "jupyter",
     "jupyterlab",
-    "jupyterlab extension"
+    "jupyterlab-extension"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab-github",
   "bugs": {


### PR DESCRIPTION
Change `jupyterlab extension` to `jupyterlab-extension` in keywords for better interoperability between different packaging systems.