### PR TITLE
Allow for private repos to be viewed if the user is authenticated.

### DIFF
--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -68,7 +68,9 @@ class GitHubHandler(APIHandler):
         c = GitHubConfig(config=self.config)
         try:
             api_path = url_path_join(c.api_url, url_escape(path))
-            params = {'per_page': 100}
+            query = self.request.query_arguments
+            params = { key: query[key][0].decode() for key in query }
+            params['per_page'] = 100
             if c.access_token != '':
                 # Preferentially use the access_token if set
                 params['access_token'] = c.access_token


### PR DESCRIPTION
This allows for private repos to be viewed if the user is authenticated using an `access_token`. Along with #47, fixes #23. The strategy for listing repositories is:

1. Check for the repositories under the `/orgs` endpoint. If the user is authenticated and has access to private repos in that org, those will be listed.
2. If the user-name doesn't correspond to an `org`, we check if the name is the same as that of the currently authenticated user.
3. If the user-name is the same as the currently authenticated user, get the repos they own using the `user/repos` endpoint. We *don't* get all the repos on which they are collaborators, which can be a truly unwieldy number.
4. If the user-name is not the same as the currently authenticaed user, get the repo listing for all the public repositories using the `/users/username/repos` endpoint.

cc @dhirschfeld 