### PR TITLE
Add ability to configure the GitHub base url

### DIFF
--- a/schema/drive.json
+++ b/schema/drive.json
@@ -6,6 +6,9 @@
   "properties": {
     "defaultRepo": {
       "type": "string", "title": "Default Repository", "default": ""
+    },
+    "gitHubBaseUrl": {
+      "type": "string", "title": "The GitHub URL", "default": "https://github.com"
     }
   },
   "type": "object"

--- a/schema/drive.json
+++ b/schema/drive.json
@@ -7,8 +7,8 @@
     "defaultRepo": {
       "type": "string", "title": "Default Repository", "default": ""
     },
-    "gitHubBaseUrl": {
-      "type": "string", "title": "The GitHub URL", "default": "https://github.com"
+    "baseUrl": {
+      "type": "string", "title": "The GitHub Base URL", "default": "https://github.com"
     }
   },
   "type": "object"

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -127,9 +127,17 @@ class GitHubFileBrowser extends Widget {
 
   /**
    * The GitHub base URL
-   * Set by the settingsRegistry change hook
    */
-  baseUrl: string;
+  get baseUrl(): string {
+    return this._baseUrl;
+  }
+
+  /**
+   * The GitHub base URL is set by the settingsRegistry change hook
+   */
+  set baseUrl(url: string) {
+    this._baseUrl = url;
+  }
 
   /**
    * React to a change in user.
@@ -251,6 +259,7 @@ class GitHubFileBrowser extends Widget {
 
   private _browser: FileBrowser;
   private _drive: GitHubDrive;
+  private _baseUrl: string;
   private _errorPanel: GitHubErrorPanel | null;
   private _openGitHubButton: ToolbarButton;
   private _launchBinderButton: ToolbarButton;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -36,6 +36,11 @@ import {
 const MY_BINDER_BASE_URL = 'https://mybinder.org/v2/gh';
 
 /**
+ * The GitHub base url.
+ */
+export const DEFAULT_GITHUB_BASE_URL = 'https://github.com';
+
+/**
  * The className for disabling the mybinder button.
  */
 const MY_BINDER_DISABLED = 'jp-MyBinderButton-disabled';
@@ -45,7 +50,6 @@ const MY_BINDER_DISABLED = 'jp-MyBinderButton-disabled';
  */
 export
 class GitHubFileBrowser extends Widget {
-  gitHubBaseUrl: string;
   constructor(browser: FileBrowser, drive: GitHubDrive) {
     super();
     this.addClass('jp-GitHubBrowser');
@@ -60,12 +64,12 @@ class GitHubFileBrowser extends Widget {
     this.userName.node.title = 'Click to edit user/organization';
     this._browser.toolbar.addItem('user', this.userName);
     this.userName.name.changed.connect(this._onUserChanged, this);
-    this.gitHubBaseUrl = "https://github.com"
+    this.baseUrl = DEFAULT_GITHUB_BASE_URL;
     // Create a button that opens GitHub at the appropriate
     // repo+directory.
     this._openGitHubButton = new ToolbarButton({
       onClick: () => {
-        let url = this.gitHubBaseUrl;
+        let url = this.baseUrl;
         // If there is no valid user, open the GitHub homepage.
         if (!this._drive.validUser) {
           window.open(url);
@@ -113,12 +117,19 @@ class GitHubFileBrowser extends Widget {
     this._onPathChanged();
 
     this._drive.rateLimitedState.changed.connect(this._updateErrorPanel, this);
+
   }
 
   /**
    * An editable widget hosting the current user name.
    */
   readonly userName: GitHubEditableName;
+
+  /**
+   * The GitHub base URL
+   * Set by the settingsRegistry change hook
+   */
+  baseUrl: string;
 
   /**
    * React to a change in user.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -36,11 +36,6 @@ import {
 const MY_BINDER_BASE_URL = 'https://mybinder.org/v2/gh';
 
 /**
- * The GitHub base url.
- */
-const GITHUB_BASE_URL = 'https://github.com';
-
-/**
  * The className for disabling the mybinder button.
  */
 const MY_BINDER_DISABLED = 'jp-MyBinderButton-disabled';
@@ -50,6 +45,7 @@ const MY_BINDER_DISABLED = 'jp-MyBinderButton-disabled';
  */
 export
 class GitHubFileBrowser extends Widget {
+  gitHubBaseUrl: string;
   constructor(browser: FileBrowser, drive: GitHubDrive) {
     super();
     this.addClass('jp-GitHubBrowser');
@@ -64,12 +60,12 @@ class GitHubFileBrowser extends Widget {
     this.userName.node.title = 'Click to edit user/organization';
     this._browser.toolbar.addItem('user', this.userName);
     this.userName.name.changed.connect(this._onUserChanged, this);
-
+    this.gitHubBaseUrl = "https://github.com"
     // Create a button that opens GitHub at the appropriate
     // repo+directory.
     this._openGitHubButton = new ToolbarButton({
       onClick: () => {
-        let url = GITHUB_BASE_URL;
+        let url = this.gitHubBaseUrl;
         // If there is no valid user, open the GitHub homepage.
         if (!this._drive.validUser) {
           window.open(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import {
 } from './contents';
 
 import {
-  GitHubFileBrowser
+  GitHubFileBrowser, DEFAULT_GITHUB_BASE_URL
 } from './browser';
 
 import '../style/index.css';
@@ -71,11 +71,16 @@ function activateFileBrowser(app: JupyterLab, manager: IDocumentManager, factory
   restorer.add(gitHubBrowser, NAMESPACE);
   app.shell.addToLeftArea(gitHubBrowser, { rank: 102 });
 
+  const onSettingsUpdated = (settings: ISettingRegistry.ISettings) => {
+    const baseUrl = settings.get('baseUrl').composite as string | null | undefined;
+    gitHubBrowser.baseUrl = baseUrl || DEFAULT_GITHUB_BASE_URL;
+  };
+
   // Fetch the initial state of the settings.
   Promise.all([settingRegistry.load(PLUGIN_ID), app.restored])
   .then(([settings]) => {
-    const gitHubBaseUrl = settings.get('gitHubBaseUrl').composite as string;
-    gitHubBrowser.gitHubBaseUrl = gitHubBaseUrl;
+    settings.changed.connect(onSettingsUpdated);
+    onSettingsUpdated(settings);
     const defaultRepo = settings.get('defaultRepo').composite as string | null;
     if (defaultRepo) {
       browser.model.restored.then( () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ function activateFileBrowser(app: JupyterLab, manager: IDocumentManager, factory
   // Fetch the initial state of the settings.
   Promise.all([settingRegistry.load(PLUGIN_ID), app.restored])
   .then(([settings]) => {
+    const gitHubBaseUrl = settings.get('gitHubBaseUrl').composite as string;
+    gitHubBrowser.gitHubBaseUrl = gitHubBaseUrl;
     const defaultRepo = settings.get('defaultRepo').composite as string | null;
     if (defaultRepo) {
       browser.model.restored.then( () => {


### PR DESCRIPTION
This adds the ability to configure the GitHub base url which is required for the "Open in GitHub" button to work with GitHub Enterprise.

The code does appear to work! It's the first Typescript/JS I've ever written so I wasn't really sure what I was doing. Consequently it might be a pretty poor implementation so I'm not fussed if this isn't merged as-is. It would be nice to get this ability added in some fashion though - it's the last piece of the puzzle for full GitHub Enterprise support.

![image](https://user-images.githubusercontent.com/881019/39079942-e8b86486-4567-11e8-8678-fec4243aa274.png)
