### PR TITLE
DOC: extending README.md with the development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,22 @@ and under the GitHub settings add
 ```
 where `owner` is the GitHub user/org,
 and `repository` is the name of the repository you want to open.
+
+## Development
+
+For a development install, do the following in the repository directory:
+
+```bash
+jlpm install
+jlpm run build
+jupyter labextension link .
+```
+
+You can then run JupyterLab in developer mode to automatically pick up changes
+to `@jupyterlab/github`. Launch JupyterLab using
+```bash
+jupyter lab --watch
+```
+This will automatically recompile `@jupyterlab/github` upon changes, and
+JupyterLab will rebuild itself. You should then be able to refresh the page and
+see your changes.


### PR DESCRIPTION
I noticed that there is no `Development` section in the README.md file. This PR attempts to fix it (based on [jupyterlab-google-drive](https://github.com/jupyterlab/jupyterlab-google-drive#development) and a little on [ipysheet](https://github.com/QuantStack/ipysheet#installation)).