### PR TITLE
Allow setting the accessToken from JupyterLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test/build/*
 node_modules/
 .pytest_cache/
 .vscode/
+.idea/
 .ipynb_checkpoints/
 npm-debug.log
 package-lock.json

--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -25,8 +25,8 @@ class GitHubConfig(Configurable):
         help=(
             "If True the access token specified in the JupyterLab settings "
             "will take precedence. If False the token specified in JupyterLab "
-            "will be ignored. This may be desirable for security purposes to "
-            "encourage users to install the server extension."
+            "will be ignored. Storing your access token in the client can "
+            "present a security risk so be careful if enabling this setting."
         )
     )
     access_token = Unicode(

--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -78,7 +78,14 @@ class GitHubHandler(APIHandler):
             api_path = url_path_join(api_url, url_escape(path))
             params['per_page'] = 100
             if not c.allow_client_side_access_token:
-                # TODO: warn somehow?
+                msg = (
+                    "Client side (JupyterLab) access tokens have been disabled "
+                    "for security reasons.\nPlease remove your access token "
+                    "from JupyterLab and instead add it to your notebook "
+                    "configuration file:\n"
+                    "    c.GitHubConfig.access_token = '<TOKEN>'\n"
+                )
+                self.log.warn(msg)
                 client_side_access_token = params.pop('access_token', None)
             if 'access_token' not in params:
                 if c.access_token != '':

--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -29,6 +29,10 @@ class GitHubConfig(Configurable):
             "present a security risk so be careful if enabling this setting."
         )
     )
+    api_url = Unicode(
+        'https://api.github.com', config=True,
+        help="The url for the GitHub api"
+    )
     access_token = Unicode(
         '', config=True,
         help=(
@@ -74,8 +78,7 @@ class GitHubHandler(APIHandler):
         try:
             query = self.request.query_arguments
             params = {key: query[key][0].decode() for key in query}
-            api_url = params.pop('api_url', 'https://api.github.com')
-            api_path = url_path_join(api_url, url_escape(path))
+            api_path = url_path_join(c.api_url, url_escape(path))
             params['per_page'] = 100
             if not c.allow_client_side_access_token:
                 client_side_access_token = params.pop('access_token', None)

--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -78,15 +78,16 @@ class GitHubHandler(APIHandler):
             api_path = url_path_join(api_url, url_escape(path))
             params['per_page'] = 100
             if not c.allow_client_side_access_token:
-                msg = (
-                    "Client side (JupyterLab) access tokens have been disabled "
-                    "for security reasons.\nPlease remove your access token "
-                    "from JupyterLab and instead add it to your notebook "
-                    "configuration file:\n"
-                    "    c.GitHubConfig.access_token = '<TOKEN>'\n"
-                )
-                self.log.warn(msg)
                 client_side_access_token = params.pop('access_token', None)
+                if client_side_access_token is None:
+                    msg = (
+                        "Client side (JupyterLab) access tokens have been "
+                        "disabled for security reasons.\nPlease remove your "
+                        "access token from JupyterLab and instead add it to "
+                        "your notebook configuration file:\n"
+                        "c.GitHubConfig.access_token = '<TOKEN>'\n"
+                    )
+                    self.log.warn(msg)
             if 'access_token' not in params:
                 if c.access_token != '':
                     # Preferentially use the access_token if set

--- a/schema/drive.json
+++ b/schema/drive.json
@@ -4,15 +4,21 @@
   "title": "GitHub",
   "description": "Settings for the GitHub plugin.",
   "properties": {
-    "defaultRepo": {
-      "type": "string",
-      "title": "Default Repository",
-      "default": ""
-    },
     "baseUrl": {
       "type": "string",
       "title": "The GitHub Base URL",
       "default": "https://github.com"
+    },
+    "accessToken": {
+      "type": "string",
+      "title": "A GitHub Personal Access Token",
+      "description": "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token",
+      "default": ""
+    },
+    "defaultRepo": {
+      "type": "string",
+      "title": "Default Repository",
+      "default": ""
     }
   },
   "type": "object"

--- a/schema/drive.json
+++ b/schema/drive.json
@@ -12,7 +12,7 @@
     "accessToken": {
       "type": "string",
       "title": "A GitHub Personal Access Token",
-      "description": "https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token",
+      "description": "WARNING: For security reasons access tokens should be set in the server extension.",
       "default": ""
     },
     "defaultRepo": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -21,11 +21,6 @@ import { GitHubDrive, parsePath } from './contents';
 const MY_BINDER_BASE_URL = 'https://mybinder.org/v2/gh';
 
 /**
- * The GitHub base url.
- */
-export const DEFAULT_GITHUB_BASE_URL = 'https://github.com';
-
-/**
  * The className for disabling the mybinder button.
  */
 const MY_BINDER_DISABLED = 'jp-MyBinderButton-disabled';
@@ -51,12 +46,11 @@ export class GitHubFileBrowser extends Widget {
       this._onUserChanged,
       this
     );
-    this.baseUrl = DEFAULT_GITHUB_BASE_URL;
     // Create a button that opens GitHub at the appropriate
     // repo+directory.
     this._openGitHubButton = new ToolbarButton({
       onClick: () => {
-        let url = this.baseUrl;
+        let url = this._drive.baseUrl;
         // If there is no valid user, open the GitHub homepage.
         if (!this._drive.validUser) {
           window.open(url);
@@ -141,20 +135,6 @@ export class GitHubFileBrowser extends Widget {
    * An editable widget hosting the current user name.
    */
   readonly userName: GitHubEditableName;
-
-  /**
-   * The GitHub base URL
-   */
-  get baseUrl(): string {
-    return this._baseUrl;
-  }
-
-  /**
-   * The GitHub base URL is set by the settingsRegistry change hook
-   */
-  set baseUrl(url: string) {
-    this._baseUrl = url;
-  }
 
   /**
    * React to a change in user.
@@ -286,7 +266,6 @@ export class GitHubFileBrowser extends Widget {
 
   private _browser: FileBrowser;
   private _drive: GitHubDrive;
-  private _baseUrl: string;
   private _errorPanel: GitHubErrorPanel | null;
   private _openGitHubButton: ToolbarButton;
   private _launchBinderButton: ToolbarButton;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -136,17 +136,6 @@ export class GitHubDrive implements Contents.IDrive {
   }
 
   /**
-   * The GitHub api URL
-   */
-  get apiUrl(): string {
-    if (this.baseUrl === DEFAULT_GITHUB_BASE_URL) {
-      return DEFAULT_GITHUB_API_URL;
-    } else {
-      return URLExt.join(this.baseUrl, '/api/v3');
-    }
-  }
-
-  /**
    * The GitHub access token
    */
   get accessToken(): string | null | undefined {
@@ -548,17 +537,15 @@ export class GitHubDrive implements Contents.IDrive {
           params[key] = value;
         }
       }
-      let baseUrl;
+      let requestUrl: string;
       if (result === true) {
-        baseUrl = URLExt.join(this._serverSettings.baseUrl, 'github');
-        // add the api_url as a query parameter
-        params['api_url'] = encodeURIComponent(this.apiUrl);
+        requestUrl = URLExt.join(this._serverSettings.baseUrl, 'github');
         // add the access token if defined
         if (this.accessToken) {
           params['access_token'] = this.accessToken;
         }
       } else {
-        baseUrl = this.apiUrl;
+        requestUrl = DEFAULT_GITHUB_API_URL;
         if (this.accessToken) {
           showDialog({
             title: 'Security Alert!',
@@ -568,11 +555,8 @@ export class GitHubDrive implements Contents.IDrive {
           });
         }
       }
-      let requestUrl;
       if (path) {
-        requestUrl = URLExt.join(baseUrl, path);
-      } else {
-        requestUrl = baseUrl;
+        requestUrl = URLExt.join(requestUrl, path);
       }
       let newQuery = Object.keys(params)
         .map(key => `${key}=${params[key]}`)

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -11,6 +11,8 @@ import { ObservableValue } from '@jupyterlab/observables';
 
 import { Contents, ServerConnection } from '@jupyterlab/services';
 
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+
 import {
   browserApiRequest,
   proxiedApiRequest,
@@ -558,8 +560,12 @@ export class GitHubDrive implements Contents.IDrive {
       } else {
         baseUrl = this.apiUrl;
         if (this.accessToken) {
-          // Security Alert!
-          // Client side access tokens have to be enabled in the server extension.
+          showDialog({
+            title: 'Security Alert!',
+            body:
+              'Client side access tokens have to be enabled in the server extension.',
+            buttons: [Dialog.warnButton({ label: 'OK' })]
+          });
         }
       }
       let requestUrl;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -11,8 +11,6 @@ import { ObservableValue } from '@jupyterlab/observables';
 
 import { Contents, ServerConnection } from '@jupyterlab/services';
 
-import { Dialog, showDialog } from '@jupyterlab/apputils';
-
 import {
   browserApiRequest,
   proxiedApiRequest,
@@ -512,6 +510,7 @@ export class GitHubDrive implements Contents.IDrive {
             this.rateLimitedState.set(true);
           }
         } else {
+          console.error(err.message);
           console.warn(
             'GitHub: cannot find user. ' + 'Perhaps you misspelled something?'
           );
@@ -546,14 +545,6 @@ export class GitHubDrive implements Contents.IDrive {
         }
       } else {
         requestUrl = DEFAULT_GITHUB_API_URL;
-        if (this.accessToken) {
-          showDialog({
-            title: 'Security Alert!',
-            body:
-              'Client side access tokens have to be enabled in the server extension.',
-            buttons: [Dialog.warnButton({ label: 'OK' })]
-          });
-        }
       }
       if (path) {
         requestUrl = URLExt.join(requestUrl, path);

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -546,16 +546,21 @@ export class GitHubDrive implements Contents.IDrive {
           params[key] = value;
         }
       }
-      if (this.accessToken) {
-        params['access_token'] = this.accessToken;
-      }
       let baseUrl;
       if (result === true) {
         baseUrl = URLExt.join(this._serverSettings.baseUrl, 'github');
         // add the api_url as a query parameter
         params['api_url'] = encodeURIComponent(this.apiUrl);
+        // add the access token if defined
+        if (this.accessToken) {
+          params['access_token'] = this.accessToken;
+        }
       } else {
         baseUrl = this.apiUrl;
+        if (this.accessToken) {
+          // Security Alert!
+          // Client side access tokens have to be enabled in the server extension.
+        }
       }
       let requestUrl;
       if (path) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,8 +5,6 @@ import { URLExt } from '@jupyterlab/coreutils';
 
 import { ServerConnection } from '@jupyterlab/services';
 
-export const GITHUB_API = 'https://api.github.com';
-
 /**
  * Make a client-side request to the GitHub API.
  *
@@ -16,8 +14,7 @@ export const GITHUB_API = 'https://api.github.com';
  * @returns a Promise resolved with the JSON response.
  */
 export function browserApiRequest<T>(url: string): Promise<T> {
-  const requestUrl = URLExt.join(GITHUB_API, url);
-  return window.fetch(requestUrl).then(response => {
+  return window.fetch(url).then(response => {
     if (response.status !== 200) {
       return response.json().then(data => {
         throw new ServerConnection.ResponseError(response, data.message);

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { URLExt } from '@jupyterlab/coreutils';
-
 import { ServerConnection } from '@jupyterlab/services';
 
 /**
@@ -39,13 +37,7 @@ export function proxiedApiRequest<T>(
   url: string,
   settings: ServerConnection.ISettings
 ): Promise<T> {
-  // Safari can have problems with spurious redirects when there is a trailing
-  // slash before the query string, so don't add an empty part of the url.
-  const fullURL = url
-    ? URLExt.join(settings.baseUrl, 'github', url)
-    : URLExt.join(settings.baseUrl, 'github');
-
-  return ServerConnection.makeRequest(fullURL, {}, settings).then(response => {
+  return ServerConnection.makeRequest(url, {}, settings).then(response => {
     if (response.status !== 200) {
       return response.json().then(data => {
         throw new ServerConnection.ResponseError(response, data.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,9 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
-import { GitHubDrive } from './contents';
+import { GitHubDrive, DEFAULT_GITHUB_BASE_URL } from './contents';
 
-import { GitHubFileBrowser, DEFAULT_GITHUB_BASE_URL } from './browser';
+import { GitHubFileBrowser } from './browser';
 
 import '../style/index.css';
 
@@ -86,7 +86,12 @@ function activateFileBrowser(
       | string
       | null
       | undefined;
-    gitHubBrowser.baseUrl = baseUrl || DEFAULT_GITHUB_BASE_URL;
+    const accessToken = settings.get('accessToken').composite as
+      | string
+      | null
+      | undefined;
+    drive.baseUrl = baseUrl || DEFAULT_GITHUB_BASE_URL;
+    drive.accessToken = accessToken;
   };
 
   // Fetch the initial state of the settings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,12 @@ function activateFileBrowser(
       | null
       | undefined;
     drive.baseUrl = baseUrl || DEFAULT_GITHUB_BASE_URL;
+    if (accessToken) {
+      console.warn(
+        'Adding a client side access token can pose a security risk! ' +
+          'Please consider using the server extension instead.'
+      );
+    }
     drive.accessToken = accessToken;
   };
 


### PR DESCRIPTION
I'm opening this PR to discuss the pros & cons of making this setting available from within JupyterLab itself. There has been some objection to doing so as this may present some security problems in case JupyterLab is itself compromised. 

I can't really speak to the security concerns except to say that in my intended usecase that doesn't really factor in as I'm connecting to an internal GitHub Enterprise instance which is behind our firewall.

Since security isn't a large concern for my usecase I'd be keen to add this functionality as I think it's a much nicer UX for users than editing a python config file, especially for those users not even using Python - e.g. my R users.