### PR TITLE
Remove deprecated OAuth authentication.

### DIFF
--- a/jupyterlab_github/__init__.py
+++ b/jupyterlab_github/__init__.py
@@ -35,18 +35,7 @@ class GitHubConfig(Configurable):
     )
     access_token = Unicode(
         '', config=True,
-        help=(
-            "A personal access token for GitHub. If specified it takes "
-            "precedence over the `client_id` and `client_secret`"
-        )
-    )
-    client_id = Unicode(
-        '', config=True,
-        help="The Client ID for the GitHub OAuth app"
-    )
-    client_secret = Unicode(
-        '', config=True,
-        help="The Client secret for the GitHub OAuth app"
+        help="A personal access token for GitHub."
     )
     validate_cert = Bool(
         True, config=True,
@@ -96,10 +85,6 @@ class GitHubHandler(APIHandler):
             elif c.access_token != '':
                 # Preferentially use the access_token if set
                 params['access_token'] = c.access_token
-            elif c.client_id != '' and c.client_secret != '':
-                # Otherwise use client_id and client_secret if set
-                params['client_id'] = c.client_id
-                params['client_secret'] = c.client_secret
 
             api_path = url_concat(api_path, params)
             client = AsyncHTTPClient()


### PR DESCRIPTION
This removes the deprecated OAuth authentication for the server extension in favor of personal access tokens.

When a user authenticates with an OAuth app, the application gives an authentication token for the individual user. I'd like to see whether that works for this extension in a JupyterHub situation, but in any event that will not use the `client_id` approach.

Wanted to get this breaking change in for a 1.0 release.

cc @dhirschfeld 

cf #46, #47, #48