### PR TITLE
The repo-to-directory conversion should include the owner in the path.

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -742,7 +742,7 @@ namespace Private {
     let content: Contents.IModel[] = repos.map(repo => {
       return {
         name: repo.name,
-        path: repo.name,
+        path: repo.full_name,
         format: 'json',
         type: 'directory',
         created: '',


### PR DESCRIPTION
This is a bugfix needed in response to jupyterlab/jupyterlab#6912

cc @jasongrout @telamonian 