### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,14 +11,14 @@ on:
       steps_to_skip:
         description: "Comma separated list of steps to skip"
         required: false
-        default: "ensure-sha"
 
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
       - name: Populate Release
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2


### PR DESCRIPTION
As noticed in https://github.com/jupyterlab/jupyterlab-github/issues/147#issuecomment-1663344660:

- [x] Add `permission` to the workflow to be able to use the trusted publisher on PyPI
- [x] Remove `ensure-sha` skipped step